### PR TITLE
feat: add copilot vs codex cli comparison post

### DIFF
--- a/src/content/blog/copilot-cli-vs-codex-cli.md
+++ b/src/content/blog/copilot-cli-vs-codex-cli.md
@@ -1,0 +1,66 @@
+---
+title: "Copilot CLI vs Codex CLI: Terminal AI Assistants Compared"
+description: "A hands-on comparison of GitHub Copilot CLI and OpenAI Codex CLI across shell integration, remote agents, configuration, and documentation experience."
+pubDatetime: 2025-10-15T00:00:00.000Z
+slug: copilot-cli-vs-codex-cli
+baseSlug: copilot-cli-vs-codex-cli
+featured: false
+tags:
+  - GitHub Copilot
+  - OpenAI Codex
+  - CLI
+  - AI Tools
+  - Developer Experience
+llmKeyIdeas:
+  - "Shell integration"
+  - "Remote agent customization"
+  - "Documentation discoverability"
+  - "Configuration trade-offs"
+  - "Approval workflows"
+---
+
+# Copilot CLI vs Codex CLI: Terminal AI Assistants Compared
+
+Developers now have two heavyweight AI copilots to choose from in the terminal: GitHub Copilot CLI and OpenAI Codex CLI. After living with both tools, I put together a pragmatic comparison that highlights where each one shines—and where the friction points still exist.
+
+## Shell Integration Experience
+
+- **Copilot CLI** ships with a built-in shell runner. You can execute commands and let the assistant react immediately, which keeps the feedback loop tight.
+- **Codex CLI** does not currently embed a shell. To execute commands you have to pair it with a Model Context Protocol (MCP) server. The official GitHub MCP bridge exists, but integrating it is finicky and remote MCP connectivity is not reliable yet. That extra setup step breaks the “open and go” flow that a CLI should deliver.
+
+## Documentation and Onboarding
+
+- **Copilot CLI** benefits from GitHub’s documentation portal and VS Code integration. You can find answers quickly, and contextual help is just a `--help` away.
+- **Codex CLI** feels under-documented. The assumption seems to be that users will ask ChatGPT for instructions. Discovering advanced flags or learning how to wire MCP endpoints takes noticeably longer.
+
+## Remote Agents and Delegation
+
+- **Codex Remote Agents** are flexible. You can spin up multiple environments, pin different model versions, and even tailor the runtime per agent. Switching the approval mode to “yolo” is literally a one-click toggle, which makes experimentation frictionless.
+- **GitHub Copilot Coding Agent** focuses on a single managed workflow. Delegation works, but you cannot customize the remote environment or choose alternate runtimes. It is predictable, yet far less configurable than Codex.
+
+## Configuration Ergonomics
+
+- **Codex CLI** expects you to maintain a `config.toml`. It works, but editing TOML by hand gets old quickly—I would rather use JSON or YAML. Until a proper UI lands, the setup feels brittle.
+- **Copilot CLI** aligns with the GitHub ecosystem. Authentication, editor integration, and settings all live where you expect. If you are already invested in GitHub, the defaults just work.
+
+## IDE and Ecosystem Fit
+
+- **Copilot CLI** wins on VS Code integration. Command palettes, inline suggestions, and GitHub-hosted workflows are deeply woven together. If you spend most of your day inside VS Code, Copilot’s polish is hard to beat.
+- **Codex CLI** plays better with heterogeneous stacks. Because remote agents are configurable, you can tailor the CLI for legacy systems, experimental toolchains, or custom deployment targets.
+
+## Delegation and Workflow Control
+
+Both tools can hand tasks to remote coding agents, but their philosophies diverge:
+
+- Copilot keeps the workflow narrow, optimized for its managed agent.
+- Codex embraces modularity—remote agents, approval levels, and environment knobs encourage you to assemble your own automation stack.
+
+## Verdict
+
+Choose **GitHub Copilot CLI** if you value turnkey shell integration, first-party docs, and tight VS Code alignment. Choose **OpenAI Codex CLI** if you need customizable remote agents, flexible approval controls, and are willing to tinker with MCP servers and TOML config files. Personally, I lean on Copilot for quick terminal work and reach for Codex when I want to orchestrate bespoke automation workflows.
+
+---
+
+## 中文摘要（Traditional Chinese Summary）
+
+喜歡看繁體中文的朋友，請繼續閱讀對照文章：我們深入比較了 GitHub Copilot CLI 與 OpenAI Codex CLI 在終端機整合、遠端代理、自訂程度與文件易用性上的差異，幫助你選擇最符合團隊開發流程的工具。

--- a/src/content/blog/zh-hant/copilot-cli-vs-codex-cli.zh-hant.md
+++ b/src/content/blog/zh-hant/copilot-cli-vs-codex-cli.zh-hant.md
@@ -1,0 +1,61 @@
+---
+lang: zh-hant
+translatedFrom: en
+baseSlug: copilot-cli-vs-codex-cli
+title: "Copilot CLI vs Codex CLI：終端機 AI 助手全面比較"
+description: "深入比較 GitHub Copilot CLI 與 OpenAI Codex CLI 在終端機整合、遠端代理、自訂程度與文件體驗上的差異。"
+pubDatetime: 2025-10-15T00:00:00.000Z
+featured: false
+tags:
+  - GitHub Copilot
+  - OpenAI Codex
+  - CLI
+  - AI 工具
+  - 開發者體驗
+llmKeyIdeas:
+  - "終端機整合"
+  - "遠端代理自訂"
+  - "文件取得"
+  - "設定檔取捨"
+  - "審核流程"
+---
+
+# Copilot CLI vs Codex CLI：終端機 AI 助手全面比較
+
+開發者現在可以在終端機裡選擇兩套重量級 AI 助手：GitHub Copilot CLI 與 OpenAI Codex CLI。實際使用兩者一段時間後，我整理出最貼近實務的差異，讓你快速掌握各自的優劣勢。
+
+## 終端機整合體驗
+
+- **Copilot CLI** 內建互動 Shell，可以直接執行指令並即時取得 AI 回應，迴圈非常緊湊。
+- **Codex CLI** 目前缺少內建 Shell。若要執行指令，必須額外串接 Model Context Protocol（MCP）伺服器。雖然 GitHub 官方提供 MCP 橋接，但整合過程繁瑣，而且遠端 MCP 支援還不穩定。這些額外步驟削弱了 CLI 應有的即開即用體驗。
+
+## 文件與上手曲線
+
+- **Copilot CLI** 有 GitHub 官方文件與 VS Code 內建說明，查找說明快速，`--help` 也提供清楚指引。
+- **Codex CLI** 的文件較難找，彷彿預設使用者會直接問 ChatGPT。要了解進階參數或 MCP 設定得花更多時間摸索。
+
+## 遠端代理與委派能力
+
+- **Codex Remote Agents** 非常彈性。你可以建立多個環境、鎖定不同模型版本，甚至調整每個代理的執行環境。切換審核模式為「yolo」只要一鍵，嘗試新流程毫無阻礙。
+- **GitHub Copilot Coding Agent** 採單一路徑。雖然可以委派任務，但無法自訂遠端環境或選擇其他執行平台。流程穩定但自由度有限。
+
+## 設定體驗
+
+- **Codex CLI** 依賴 `config.toml`。雖然能運作，但長期手動維護 TOML 令人感到麻煩——我個人更偏好 JSON 或 YAML。目前缺乏友善介面，設定流程顯得脆弱。
+- **Copilot CLI** 與 GitHub 生態整合緊密。認證、編輯器整合與偏好設定都在熟悉的位置。如果團隊早已使用 GitHub，幾乎不用額外調整。
+
+## IDE 與生態適配度
+
+- **Copilot CLI** 在 VS Code 的體驗最佳。指令面板、行內建議與 GitHub 工作流程緊密連結，長時間在 VS Code 的使用者很容易愛上它的打磨程度。
+- **Codex CLI** 更適合異質環境。藉由自訂遠端代理，你能針對舊系統、實驗性工具鏈或自製部署流程調整整體體驗。
+
+## 委派與流程控制
+
+兩者都能委派任務給遠端編碼代理，但思維截然不同：
+
+- Copilot 保持流程單純，強調自家託管代理的穩定性。
+- Codex 擁抱模組化——遠端代理、審核層級與環境設定都可自由組合，適合打造客製化自動化流程。
+
+## 總結
+
+若你重視開箱即用的 Shell 整合、一手文件與 VS Code 深度連結，**GitHub Copilot CLI** 是最佳選擇。若你需要高度自訂的遠端代理、彈性的審核控制，並願意花時間調校 MCP 與 TOML 設定，**OpenAI Codex CLI** 會讓你獲得更大的掌控力。我個人會在快速終端機工作時選擇 Copilot，而在設計客製化自動化流程時改用 Codex。


### PR DESCRIPTION
## Summary
- add an English blog post comparing GitHub Copilot CLI and OpenAI Codex CLI across integration, documentation, agents, and configuration
- publish a Traditional Chinese counterpart that mirrors the same evaluation for bilingual readers

## Testing
- uv run podcast-generate --posts copilot-cli-vs-codex-cli --output-dir public/podcasts *(fails: PyPI download blocked in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68eb0489854083209e842fefccf291b4