### PR TITLE
Group Dependabot npm updates into logical bundles

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,52 @@ updates:
         patterns:
           - "astro*"
           - "@astrojs/*"
+      react-stack:
+        patterns:
+          - "react"
+          - "react-dom"
+          - "@types/react"
+      tailwind:
+        patterns:
+          - "tailwindcss"
+          - "@tailwindcss/*"
+          - "@astrojs/tailwind"
+          - "prettier-plugin-tailwindcss"
+      typescript:
+        patterns:
+          - "typescript"
+          - "tsx"
+          - "@types/*"
+      linting:
+        patterns:
+          - "eslint"
+          - "eslint-*"
+          - "@typescript-eslint/*"
+          - "astro-eslint-parser"
+      formatting:
+        patterns:
+          - "prettier"
+          - "prettier-plugin-*"
+      testing:
+        patterns:
+          - "@playwright/test"
+      commit-tooling:
+        patterns:
+          - "husky"
+          - "lint-staged"
+          - "commitizen"
+          - "cz-*"
+      content-pipeline:
+        patterns:
+          - "remark-*"
+          - "rss"
+          - "@types/rss"
+          - "satori"
+          - "@resvg/*"
+          - "fuse.js"
+          - "github-slugger"
+          - "mermaid"
+          - "dotenv"
     commit-message:
       prefix: "chore"
       include: "scope"


### PR DESCRIPTION
## Summary
- expand Dependabot's npm groups to bundle related ecosystem updates
- add dedicated groups for Astro, React, Tailwind, TypeScript, linting, formatting, testing, commit tooling, and content processing dependencies

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f6c5b745bc8320b51ec9b219f17060